### PR TITLE
Update schedule is now set on every `odd` two hours in JST (according with rotation of stages)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -21,7 +21,7 @@ functions:
     events:
       - name: at-every-schedule-rotation
       - description: At every schedule rotation.
-      - schedule: cron(0 1/2 * * ? *)
+      - schedule: cron(0 */2 * * ? *)
 
 package:
   exclude:


### PR DESCRIPTION
Confirmed the next 10 schedules are:

1. Thu, 17 Jan 2019 08:00:00 GMT
2. Thu, 17 Jan 2019 10:00:00 GMT
3. Thu, 17 Jan 2019 12:00:00 GMT
4. Thu, 17 Jan 2019 14:00:00 GMT
5. Thu, 17 Jan 2019 16:00:00 GMT
6. Thu, 17 Jan 2019 18:00:00 GMT
7. Thu, 17 Jan 2019 20:00:00 GMT
8. Thu, 17 Jan 2019 22:00:00 GMT
9. Fri, 18 Jan 2019 00:00:00 GMT
10. Fri, 18 Jan 2019 02:00:00 GMT

Fixes #3 